### PR TITLE
Set include directories and run out-of-context synth in utilization script

### DIFF
--- a/scripts/utilization.tcl
+++ b/scripts/utilization.tcl
@@ -13,9 +13,10 @@ if { $part eq "" || $top eq "" || $incdir eq "" || [llength $sources] == 0 } {
 
 # Read all source files, supplying the include directory so that
 # `\`include` directives resolve correctly
-read_verilog -sv -include $incdir $sources
+set_property include_dirs $incdir [current_fileset]
+read_verilog -sv $sources
 
-# Run synthesis and emit utilization report
-synth_design -top $top -part $part
+# Run project-less out-of-context synthesis and emit utilization report
+synth_design -top $top -part $part -mode out_of_context
 report_utilization -file logs/utilization.rpt
 exit


### PR DESCRIPTION
## Summary
- Configure include directory on the current fileset
- Perform project-less out-of-context synthesis to generate utilization report

## Testing
- `make test` *(fails: iverilog: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3bcb565c8328b4450beea0a32627