### PR TITLE
Expose program counter via debug output

### DIFF
--- a/docs/cpu.md
+++ b/docs/cpu.md
@@ -22,6 +22,7 @@
 | --------- | --------- | ---- | ----------- |
 | clk       | input     | wire | System clock |
 | reset     | input     | wire | Asynchronous reset |
+| debug_pc  | output    | wire [31:0] | Current program counter for debug |
 
 ## Signals
 

--- a/src/core/cpu.v
+++ b/src/core/cpu.v
@@ -8,7 +8,8 @@ module cpu #(
     parameter         DMEM_FILE  = "src/data_mem.mem"
 ) (
     input wire clk,
-    input wire reset
+    input wire reset,
+    output wire [31:0] debug_pc
 );
 
 
@@ -72,7 +73,8 @@ module cpu #(
       .is_branch(is_branch),
       .is_jal(is_jal),
       .is_jalr(is_jalr),
-      .instr(instr)
+      .instr(instr),
+      .debug_pc(debug_pc)
   );
 
 endmodule

--- a/src/core/datapath.v
+++ b/src/core/datapath.v
@@ -33,7 +33,8 @@ module datapath #(
     input wire is_jalr,
 
 
-    output wire [31:0] instr
+    output wire [31:0] instr,
+    output wire [31:0] debug_pc
 );
 
 
@@ -79,6 +80,7 @@ module datapath #(
   );
 
   assign pc_plus4 = pc_current + 32'd4;
+  assign debug_pc = pc_current;
 
 
   regfile u_rf (

--- a/tb/cpu_tb.v
+++ b/tb/cpu_tb.v
@@ -11,6 +11,7 @@ module cpu_tb;
   reg clk = 1'b0;
   reg reset = 1'b1;
   integer k;
+  wire [31:0] debug_pc;
 
   cpu #(
       .ADDR_WIDTH(ADDR_WIDTH),
@@ -18,7 +19,8 @@ module cpu_tb;
       .DMEM_FILE (DMEM_FILE)
   ) dut (
       .clk  (clk),
-      .reset(reset)
+      .reset(reset),
+      .debug_pc(debug_pc)
   );
 
   always #5 clk = ~clk;
@@ -32,7 +34,7 @@ module cpu_tb;
 
   always @(posedge clk)
     if (!reset) begin
-      $display("t=%0t PC=%h INSTR=%h", $time, dut.u_datapath.pc_current, dut.u_datapath.instr);
+      $display("t=%0t PC=%h INSTR=%h", $time, debug_pc, dut.u_datapath.instr);
     end
 
   always @(posedge clk) begin
@@ -88,7 +90,7 @@ module cpu_tb;
 
   //       if (dut.u_datapath.instr === 32'h0000_006F) begin
   //         $display("[INFO] Reached END_SENTINEL (jal x0,0) at PC=%h, cycle %0d",
-  //                  dut.u_datapath.pc_current, cycles);
+  //                  debug_pc, cycles);
   //         finished = 1'b1;
   //         disable end_test;
   //       end


### PR DESCRIPTION
## Summary
- add `debug_pc` output on datapath and expose through CPU top-level
- tap new `debug_pc` in cpu_tb for monitoring
- document `debug_pc` port in CPU docs

## Testing
- `make test` *(fails: iverilog: command not found)*
- `apt-get update` *(fails: repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac479158b08328a21851f3f3f86a88