### PR TITLE
Prevent CPU logic from being pruned in synthesis

### DIFF
--- a/src/core/cpu.v
+++ b/src/core/cpu.v
@@ -9,11 +9,14 @@ module cpu #(
 ) (
     input wire clk,
     input wire reset,
-    output wire [31:0] debug_pc
+    output wire [31:0] debug_pc,
+    output wire [31:0] debug_instr,
+    output wire [31:0] debug_alu
 );
 
 
-  wire [31:0] instr;
+  (* KEEP = "true" *) wire [31:0] instr;
+  (* KEEP = "true" *) wire [31:0] debug_alu_int;
   wire [ 6:0] opcode;
   wire [4:0] rd, rs1, rs2;
   wire [ 2:0] funct3;
@@ -25,7 +28,7 @@ module cpu #(
   wire [1:0] op1_sel, wb_sel;
   wire is_branch, is_jal, is_jalr;
 
-  controller u_controller (
+  (* DONT_TOUCH = "true" *) controller u_controller (
       .instr(instr),
       .opcode(opcode),
       .rd(rd),
@@ -47,7 +50,7 @@ module cpu #(
       .is_jalr(is_jalr)
   );
 
-  datapath #(
+  (* DONT_TOUCH = "true" *) datapath #(
       .DATA_WIDTH(DATA_WIDTH),
       .ADDR_WIDTH(ADDR_WIDTH),
       .IMEM_FILE (IMEM_FILE),
@@ -74,7 +77,11 @@ module cpu #(
       .is_jal(is_jal),
       .is_jalr(is_jalr),
       .instr(instr),
-      .debug_pc(debug_pc)
+      .debug_pc(debug_pc),
+      .debug_alu(debug_alu_int)
   );
+
+  assign debug_instr = instr;
+  assign debug_alu   = debug_alu_int;
 
 endmodule

--- a/src/core/datapath.v
+++ b/src/core/datapath.v
@@ -34,7 +34,8 @@ module datapath #(
 
 
     output wire [31:0] instr,
-    output wire [31:0] debug_pc
+    output wire [31:0] debug_pc,
+    output wire [31:0] debug_alu
 );
 
 
@@ -83,7 +84,7 @@ module datapath #(
   assign debug_pc = pc_current;
 
 
-  regfile u_rf (
+  (* DONT_TOUCH = "true" *) regfile u_rf (
       .clk      (clk),
       .reset    (reset),
       .rs1      (rs1),
@@ -101,7 +102,7 @@ module datapath #(
   assign op_b = (alu_src) ? imm_out : rs2_data;
 
 
-  alu u_alu (
+  (* DONT_TOUCH = "true" *) alu u_alu (
       .op_a      (op_a),
       .op_b      (op_b),
       .alu_ctrl  (alu_ctrl),
@@ -110,7 +111,7 @@ module datapath #(
   );
 
 
-  instr_mem #(
+  (* DONT_TOUCH = "true" *) instr_mem #(
       .ADDR_WIDTH(ADDR_WIDTH),
       .MEM_FILE  (IMEM_FILE)
   ) u_imem (
@@ -119,7 +120,7 @@ module datapath #(
   );
 
 
-  data_mem #(
+  (* DONT_TOUCH = "true" *) data_mem #(
       .ADDR_WIDTH(ADDR_WIDTH),
       .MEM_FILE  (DMEM_FILE)
   ) u_dmem (
@@ -137,5 +138,7 @@ module datapath #(
       (wb_sel == `WB_MEM) ? rdata      :
       (wb_sel == `WB_PC4) ? pc_plus4   :
                             32'b0;
+
+  assign debug_alu = alu_result;
 
 endmodule


### PR DESCRIPTION
## Summary
- Expose instruction and ALU result at top level
- Preserve CPU submodules with DONT_TOUCH attributes
- Restore Makefile to explicit source list

## Testing
- `make check` *(fails: iverilog: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y iverilog` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4b31cc388328b861178ef459e5cf