### PR TITLE
Fix report command in Vivado scripts

### DIFF
--- a/scripts/reports.tcl
+++ b/scripts/reports.tcl
@@ -19,7 +19,7 @@ read_verilog -sv $sources
 synth_design -top $top -part $part -mode out_of_context
 
 # Emit reports
-report_synth            -file logs/synth.rpt
+report_synthesis -file logs/synth.rpt
 report_timing_summary   -file logs/timing_summary.rpt
 report_clock_networks   -file logs/clock_networks.rpt
 report_clock_interaction -file logs/clock_interaction.rpt


### PR DESCRIPTION
## Summary
- use Vivado's `report_synthesis` command instead of deprecated `report_synth`

## Testing
- `make report` *(fails: Missing: /opt/Xilinx/Vivado/2025.1/2025.1/Vivado/settings64.sh)*

------
https://chatgpt.com/codex/tasks/task_e_68ad330be9f88328b0b5775bfc71b3c6