### PR TITLE
docs: streamline system architecture table

### DIFF
--- a/docs/internship_report.md
+++ b/docs/internship_report.md
@@ -103,15 +103,16 @@ Key Vivado metrics for the synthesized core:
 
 ## 11. System Architecture
 
-| Layer | Description | Citations |
-|-------|-------------|-----------|
-| **Top-Level CPU** | Integrates the controller and datapath, wiring instruction fields, control signals, and memory interfaces | |
-| **Controller** | Extracts opcode, registers, immediates, and derives control signals via `decoder_glue` and `alu_control` | |
-| **Datapath** | Coordinates instruction fetch, register file access, ALU operations, branch logic, memory access, and write-back selection | |
-| **Next PC Unit** | Chooses sequential PC or branch/jump targets, aligning JALR addresses and verifying alignment | |
-| **Leaf Modules** | ALU supports arithmetic, logical, and shift operations with zero detection; branch comparator evaluates conditional jumps | |
-| **Figure 3:** _Controller–Datapath Interaction_  |
-| ![Controller–Datapath Interaction Placeholder](path/to/controller_datapath_interaction.png) |
+| Layer | Description |
+|-------|-------------|
+| **Top-Level CPU** | Integrates the controller and datapath, wiring instruction fields, control signals, and memory interfaces |
+| **Controller** | Extracts opcode, registers, immediates, and derives control signals via `decoder_glue` and `alu_control` |
+| **Datapath** | Coordinates instruction fetch, register file access, ALU operations, branch logic, memory access, and write-back selection |
+| **Next PC Unit** | Chooses sequential PC or branch/jump targets, aligning JALR addresses and verifying alignment |
+| **Leaf Modules** | ALU supports arithmetic, logical, and shift operations with zero detection; branch comparator evaluates conditional jumps |
+
+> **Figure 3:** _Controller–Datapath Interaction_
+> ![Controller–Datapath Interaction Placeholder](path/to/controller_datapath_interaction.png)
 
 A complete inventory of modules and their interfaces is documented for quick reference.
 


### PR DESCRIPTION
## Summary
- drop unused citations column from system architecture table
- move Controller–Datapath figure outside the table for proper rendering

## Testing
- `make test` *(fails: iverilog not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad996f57348328908fdf4fb20e1a1c