### PR TITLE
Use shared PASS macros in tests

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,13 +2,17 @@ RISCV ?= riscv64-unknown-elf
 CC    := $(RISCV)-gcc
 OBJC  := $(RISCV)-objcopy
 
-CFLAGS := -march=rv32i -mabi=ilp32 -nostdlib -nostartfiles -Wl,-Tcommon.ld -static
+PASS_ADDR ?= 0x20
+PASS_DATA ?= 0xC0DECAFE
+
+CFLAGS := -march=rv32i -mabi=ilp32 -nostdlib -nostartfiles -Wl,-Tcommon.ld -static \
+          -DPASS_ADDR=$(PASS_ADDR) -DPASS_DATA=$(PASS_DATA)
 ASM    := r_alu.S i_alu.S branches.S jumps.S mem_rw.S x0_guard.S
 
 # rule: .S -> .elf -> .mem (verilog)
 all: $(ASM:.S=.mem)
 
-%.elf: %.S common.ld
+%.elf: %.S common.ld PASS_INC.S
 	$(CC) $(CFLAGS) -o $@ $<
 
 %.mem: %.elf

--- a/tests/PASS_INC.S
+++ b/tests/PASS_INC.S
@@ -1,0 +1,7 @@
+#ifndef PASS_ADDR
+#define PASS_ADDR 0x20
+#endif
+
+#ifndef PASS_DATA
+#define PASS_DATA 0xC0DECAFE
+#endif

--- a/tests/branches.S
+++ b/tests/branches.S
@@ -1,5 +1,6 @@
     .section .text
     .globl _start
+#include "PASS_INC.S"
 _start:
     addi x1, x0, 10
     addi x2, x0, 10
@@ -25,7 +26,6 @@ _start:
     addi x0, x0, 1
 6:
     # PASS
-    lui  x14, %hi(0xC0DECAFE)
-    addi x14, x14, %lo(0xC0DECAFE)
-    sw   x14, 0x20(x0)
+    li   t0, PASS_DATA
+    sw   t0, PASS_ADDR(x0)
 1:  jal  x0, 0

--- a/tests/i_alu.S
+++ b/tests/i_alu.S
@@ -1,5 +1,6 @@
     .section .text
     .globl _start
+#include "PASS_INC.S"
 _start:
     addi x1, x0, 5
     addi x2, x1, -3      # 2
@@ -14,7 +15,6 @@ _start:
     sltiu x11, x8, 1     # x8 is 0xFFFFFF80; 0xFFFFFF80 < 1 (unsigned)? no => 0
 
     # PASS
-    lui  x14, %hi(0xC0DECAFE)
-    addi x14, x14, %lo(0xC0DECAFE)
-    sw   x14, 0x20(x0)
+    li   t0, PASS_DATA
+    sw   t0, PASS_ADDR(x0)
 1:  jal  x0, 0

--- a/tests/jumps.S
+++ b/tests/jumps.S
@@ -1,5 +1,6 @@
     .section .text
     .globl _start
+#include "PASS_INC.S"
 _start:
     auipc x3, 0          # x3 = PC
     jal   x1, 1f         # x1 = link = PC+4
@@ -11,7 +12,6 @@ _start:
     addi  x0, x0, 1      # skipped
 2:
     # PASS
-    lui  x14, %hi(0xC0DECAFE)
-    addi x14, x14, %lo(0xC0DECAFE)
-    sw   x14, 0x20(x0)
+    li   t0, PASS_DATA
+    sw   t0, PASS_ADDR(x0)
 1:  jal  x0, 0

--- a/tests/mem_rw.S
+++ b/tests/mem_rw.S
@@ -1,5 +1,6 @@
     .section .text
     .globl _start
+#include "PASS_INC.S"
 _start:
     # Write pattern to four words @ 0x100..0x10C, then sum to x10
     lui  x1, %hi(0x00000100)
@@ -24,7 +25,6 @@ _start:
     add  x10, x10, x9     # x10 = 10
 
     # PASS
-    lui  x14, %hi(0xC0DECAFE)
-    addi x14, x14, %lo(0xC0DECAFE)
-    sw   x14, 0x20(x0)
+    li   t0, PASS_DATA
+    sw   t0, PASS_ADDR(x0)
 1:  jal  x0, 0

--- a/tests/r_alu.S
+++ b/tests/r_alu.S
@@ -1,5 +1,6 @@
     .section .text
     .globl _start
+#include "PASS_INC.S"
 _start:
     # x1=7, x2=3
     addi x1, x0, 7
@@ -18,7 +19,6 @@ _start:
     sltu x13, x2, x1     # 1
 
     # PASS
-    lui  x14, %hi(0xC0DECAFE)
-    addi x14, x14, %lo(0xC0DECAFE)
-    sw   x14, 0x20(x0)
+    li   t0, PASS_DATA
+    sw   t0, PASS_ADDR(x0)
 1:  jal  x0, 0            # END_SENTINEL (your TB also appends one)

--- a/tests/x0_guard.S
+++ b/tests/x0_guard.S
@@ -1,5 +1,6 @@
     .section .text
     .globl _start
+#include "PASS_INC.S"
 _start:
     addi x0, x0, 123     # should have no effect
     addi x1, x0, 0       # expect x1=0
@@ -10,7 +11,6 @@ _start:
     addi x0, x0, 1
 
 1:  # PASS
-    lui  x14, %hi(0xC0DECAFE)
-    addi x14, x14, %lo(0xC0DECAFE)
-    sw   x14, 0x20(x0)
+    li   t0, PASS_DATA
+    sw   t0, PASS_ADDR(x0)
 1:  jal  x0, 0


### PR DESCRIPTION
## Summary
- Add `PASS_INC.S` header with PASS_ADDR/PASS_DATA defaults
- Update all assembly tests to include shared macros and signal PASS via t0
- Expose PASS_ADDR/PASS_DATA in tests Makefile for `.mem` generation

## Testing
- `make -C tests` *(fails: riscv64-unknown-elf-gcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68adf4ab47d48328ae4b49dbd4eb36d1