### PR TITLE
chore: remove stray comments

### DIFF
--- a/src/glue/decoder_glue.v
+++ b/src/glue/decoder_glue.v
@@ -1,16 +1,12 @@
 `timescale 1ns / 1ps
 `include "defines.vh"
-// `defines.vh` can hold WB encodings if you prefer
 
 module decoder_glue #(
     parameter DATA_WIDTH = 32
 ) (
     input wire [31:0] instr,
 
-    // immediates
     output wire [DATA_WIDTH-1:0] imm_out,
-
-    // controls to datapath
     output wire       reg_write,
     output wire       mem_read,
     output wire       mem_write,
@@ -23,7 +19,6 @@ module decoder_glue #(
     output wire [1:0] alu_op,
     output wire [2:0] imm_sel,
 
-    // optional: for next_pc/traps/etc.
     output wire is_jal,
     output wire is_jalr,
     output wire is_branch,
@@ -37,12 +32,10 @@ module decoder_glue #(
 
 );
 
-  // -------- slicer --------
   wire [4:0] rd = instr[11:7];
   wire [4:0] rs1 = instr[19:15];
   wire [4:0] rs2 = instr[24:20];
 
-  // -------- coarse decode --------
   decoder #(
       .DATA_WIDTH(DATA_WIDTH)
   ) u_dec (
@@ -60,7 +53,6 @@ module decoder_glue #(
       .is_system (is_system)
   );
 
-  // -------- main control --------
   control #(
       .DATA_WIDTH(DATA_WIDTH)
   ) u_ctl (
@@ -87,7 +79,6 @@ module decoder_glue #(
       .op1_sel   (op1_sel)
   );
 
-  // -------- immediate gen --------
   imm_gen u_imm (
       .instr  (instr),
       .imm_sel(imm_sel),  // `Imm_I/S/B/U/J` from defines.vh

--- a/src/glue/next_pc.v
+++ b/src/glue/next_pc.v
@@ -23,18 +23,4 @@ module next_pc (
       (is_branch && branch_taken) ? branch_jal_pc :
                                     pc_plus4;
 
-  wire misalign_bits = `KNOWN(pc_current[1:0]) && `KNOWN(pc_next[1:0]);
-
-  // `ifndef SYNTHESIS
-  //   always @(*) begin
-  //     if (misalign_bits) begin
-  //       #1;
-  //       if (pc_current[1:0] !== 2'b00 || pc_next[1:0] !== 2'b00) begin
-  //         $display("[%0t] ERROR: Instr addr misaligned: pc=%h next=%h", $time, pc_current, pc_next);
-  //         $stop;
-  //       end
-  //     end
-  //   end
-  // `endif
-
 endmodule

--- a/src/leaf/instr_slicer.v
+++ b/src/leaf/instr_slicer.v
@@ -20,7 +20,6 @@ module instr_slicer (
   assign rs2    = instr[24:20];
   assign funct7 = instr[31:25];
 
-  // Convenience
   assign shamt  = instr[24:20];
   assign csr    = instr[31:20];
 endmodule

--- a/src/leaf/wb_mux.v
+++ b/src/leaf/wb_mux.v
@@ -15,7 +15,6 @@ module wb_mux (
     output wire [            4:0] rd_out
 );
 
-  // wb_sel encodings
   localparam reg [1:0] WB_ALU = 2'd0;
   localparam reg [1:0] WB_MEM = 2'd1;
   localparam reg [1:0] WB_PC4 = 2'd2;

--- a/tb/alu_control_tb.v
+++ b/tb/alu_control_tb.v
@@ -7,15 +7,12 @@ module alu_control_tb;
   reg        funct7_5;
   wire [3:0] ALUCtrl;
 
-  // DUT
   alu_control uut (
       .alu_op  (ALUOp),
       .funct3  (funct3),
       .funct7_5(funct7_5),
       .alu_ctrl(ALUCtrl)
   );
-
-  // ALU Control Signals
   localparam [3:0] ALU_ADD = 4'b0000;
   localparam [3:0] ALU_SUB = 4'b0001;
   localparam [3:0] ALU_SLL = 4'b0010;
@@ -29,7 +26,6 @@ module alu_control_tb;
 
   integer failed, passed;
 
-  // Verilog-2001 "string" via packed bytes (max 32 chars)
   task check_output;
     input [3:0] expected;
     input [3:0] actual;
@@ -46,7 +42,6 @@ module alu_control_tb;
   endtask
 
   initial begin
-    // dump waveform
     $dumpfile("dump.vcd");
     $dumpvars(0, alu_control_tb);
 
@@ -54,8 +49,6 @@ module alu_control_tb;
     failed = 0;
 
     $display("\n--- ALU Control Testbench Start ---\n");
-
-    // ===== Baseline sanity =====
 
     // Test case 1: ALUOp = 00 (ADD) - generic add path
     ALUOp = 2'b00;


### PR DESCRIPTION
## Summary
- drop section and debug comments across decoder glue and next pc
- trim unused notes in instr slicer, writeback mux, and ALU control testbench

## Testing
- `make test` *(fails: iverilog: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae08d77a148328b529282ad2afce63