### PR TITLE
docs: clarify word-aligned load/store limitation

### DIFF
--- a/docs/data_mem.md
+++ b/docs/data_mem.md
@@ -30,3 +30,5 @@
 
 ## Behavior
 Implements a simple 32‑bit data memory with synchronous writes and combinational reads controlled by `we`/`re`.
+
+> **Note:** Only word-aligned load and store operations are supported. Byte or half‑word accesses and their accompanying sign‑extension logic are not implemented.

--- a/docs/internship_report.md
+++ b/docs/internship_report.md
@@ -220,6 +220,8 @@ integration tests remain outstanding.
 | regfile | Reset, sequential writes, back-to-back writes, randomized accesses, re-reset | Reads match writes, x0 constant | 154 |
 | wb_mux | ALU, MEM, PC+4 paths; kill gating; x0/x31 writes | Selected data routed; gating works | 8 |
 
+> **Limitation:** Load and store support is restricted to word-aligned operations. Byte and half-word accesses, along with any sign-extension logic, are not implemented.
+
 ### Testing Notes
 Results reflect these simulation-only tests; hardware performance and
 long-duration behavior still need evaluation.
@@ -241,7 +243,7 @@ The repository provides a complete, simulation-ready RISC-V core with comprehens
 - Integrate a cache or memory hierarchy for realistic performance evaluation.
 
 ## 18. Conclusion
-This project delivers a clean, modular foundation for RISC-V CPU exploration. The codebase’s structure, documentation, and automated tooling—now including mandatory Vivado flows—make it suitable for both educational purposes and further research or development.
+This project delivers a clean, modular foundation for RISC-V CPU exploration. The codebase’s structure, documentation, and automated tooling—now including mandatory Vivado flows—make it suitable for both educational purposes and further research or development. However, load/store capability is limited to word-aligned operations; byte and half-word accesses with sign-extension are not yet supported, so the core should be regarded as a partial RV32I implementation.
 
 ## 19. Appendices
 


### PR DESCRIPTION
## Summary
- Document that data memory only supports word-aligned loads/stores without byte or half-word accesses
- Note the same limitation in the ISA coverage discussion and conclusion to clarify partial RV32I support

## Testing
- `make test` *(fails: iverilog: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0be0efe88328beeb6335aafe7835